### PR TITLE
Add strong count function to ArenaArc

### DIFF
--- a/src/arena_arc.rs
+++ b/src/arena_arc.rs
@@ -115,6 +115,10 @@ impl<T> ArenaArc<T> {
 
         ArenaArc { block }
     }
+
+    pub fn strong_count(&self) -> usize {
+        unsafe { self.block.as_ref() }.counter.load(Relaxed)
+    }
 }
 
 impl<T> Clone for ArenaArc<T> {


### PR DESCRIPTION
This may be useful for hashconsing and bookkeeping

Example use case: I want to have a pool of hashconsigned AST objects, and I would store them in a hashmap `HashMap<Expr, ArenaArc<Expr>>`. Then if I want to garbage collect the consign, I can simply delete all `(k, v)` pairs such that `v.strong_count() == 1`.